### PR TITLE
fix changed config values overwritten with default value

### DIFF
--- a/src/main/java/net/william278/schematicupload/config/Settings.java
+++ b/src/main/java/net/william278/schematicupload/config/Settings.java
@@ -25,10 +25,10 @@ public class Settings {
 
     public Settings() {
         plugin.saveDefaultConfig();
-        plugin.getConfig().options().copyDefaults(true);
-        plugin.saveConfig();
         plugin.reloadConfig();
         FileConfiguration config = plugin.getConfig();
+        plugin.getConfig().options().copyDefaults(true);
+        plugin.saveConfig();
 
         this.language = config.getString("language", "en-gb");
         this.schematicDirectory = getSchematicDirectory();

--- a/src/main/java/net/william278/schematicupload/config/Settings.java
+++ b/src/main/java/net/william278/schematicupload/config/Settings.java
@@ -36,9 +36,9 @@ public class Settings {
         this.webServerPort = config.getInt("web_server.port", 2780);
         this.webServerUrl = config.getString("web_server.url", "").isBlank() ? "http://localhost:" + webServerPort : config.getString("web_server.url");
 
-        this.maxFileSize = config.getInt("upload_limit.max_schematic_file_size", 1500000);
-        this.uploadLimitPeriod = config.getLong("upload_limit.period_minutes", 60L);
-        this.uploadLimitCount = config.getInt("upload_limit.schematics_per_period", 3);
+        this.maxFileSize = config.getInt("upload_limits.max_schematic_file_size", 1500000);
+        this.uploadLimitPeriod = config.getLong("upload_limits.period_minutes", 60L);
+        this.uploadLimitCount = config.getInt("upload_limits.schematics_per_period", 3);
     }
 
     // Determines the custom schematic directory

--- a/src/main/java/net/william278/schematicupload/upload/UploadManager.java
+++ b/src/main/java/net/william278/schematicupload/upload/UploadManager.java
@@ -1,7 +1,12 @@
 package net.william278.schematicupload.upload;
 
 import net.william278.schematicupload.SchematicUpload;
+import org.bukkit.Bukkit;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -79,10 +84,25 @@ public class UploadManager {
     public static UploadCode addCode(UUID player) {
         UploadCode code = UploadCode.generateRandomCode();
         uploadAuthorizationCodes.put(player, code);
+        logToFile("Schematic code " + code.getCode() + " generated for " + player);
         return code;
     }
 
     public record ConsumptionResult(boolean consumed, Optional<UUID> user, String errorCode) {
     }
 
+    public static void logToFile(String message) {
+        File logFile = new File(SchematicUpload.getInstance().getDataFolder(), "schems.log");
+
+        try (FileWriter fw = new FileWriter(logFile,true);
+             PrintWriter pw = new PrintWriter(fw);) {
+            if (!logFile.exists()) {
+                logFile.createNewFile();
+            }
+            pw.println(message);
+        }
+        catch (IOException e) {
+            Bukkit.getLogger().warning(e.toString());
+        }
+    }
 }

--- a/src/main/java/net/william278/schematicupload/web/FileUploadServlet.java
+++ b/src/main/java/net/william278/schematicupload/web/FileUploadServlet.java
@@ -82,10 +82,12 @@ public class FileUploadServlet extends HttpServlet {
         try (InputStream inputStream = filePart.getInputStream();
              OutputStream outputStream = Files.newOutputStream(outputFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
             if (inputStream.available() > plugin.getSettings().maxFileSize) {
+                Files.delete(outputFile);
                 sendReply(servletResponse, 400, "Invalid schematic; too large. (Max size: " + (plugin.getSettings().maxFileSize / 1000) + "KB)");
                 return;
             }
             if (!GZipUtil.isGZipped(inputStream)) {
+                Files.delete(outputFile);
                 sendReply(servletResponse, 400, "Invalid schematic format.");
                 return;
             }


### PR DESCRIPTION
Currently when the plugin loads it rewrites the config.yml with the default one, losing your customized values. This PR reorders the config loading so that any customized values are preserved.